### PR TITLE
Handle Windows WiFi profiles safely

### DIFF
--- a/wifi.py
+++ b/wifi.py
@@ -1,13 +1,51 @@
-import subprocess
+import platform
 import re
+import subprocess
 
-def get_wifi_passwords():
-    data = subprocess.check_output('netsh wlan show profiles', shell=True)
-    profiles = re.findall("All User Profile\s*:\s(.*)", data.decode())
+
+def get_wifi_passwords() -> None:
+    """Retrieve and display stored Wi-Fi passwords using ``netsh``."""
+
+    try:
+        data = subprocess.check_output(
+            ["netsh", "wlan", "show", "profiles"],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to list profiles: {e.output.strip()}")
+        return
+
+    profiles = re.findall(r"All User Profile\s*:\s(.*)", data)
     for profile in profiles:
-        info = subprocess.check_output(f'netsh wlan show profile "{profile.strip()}" key=clear', shell=True)
-        password = re.search("Key Content\s*:\s(.*)", info.decode())
-        if password:
-            print(f"{profile.strip()}: {password.group(1)}")
+        profile_name = profile.strip()
 
-get_wifi_passwords()
+        if not re.fullmatch(r"[\w\- ]+", profile_name):
+            print(f"Skipping suspicious profile name: {profile_name!r}")
+            continue
+
+        try:
+            info = subprocess.check_output(
+                ["netsh", "wlan", "show", "profile", profile_name, "key=clear"],
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"Failed to get profile {profile_name}: {e.output.strip()}")
+            continue
+
+        password = re.search(r"Key Content\s*:\s(.*)", info)
+        if password:
+            print(f"{profile_name}: {password.group(1)}")
+
+
+def main() -> None:
+    if platform.system().lower() != "windows":
+        print("This script only runs on Windows.")
+        return
+
+    get_wifi_passwords()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Prevent execution on non-Windows platforms
- Use safer subprocess calls with validation and error handling for WiFi profiles

## Testing
- `python -m ruff check wifi.py`
- `python -m pytest`
- `python -m black wifi.py` *(fails: Config key exclude must be a string)*

------
https://chatgpt.com/codex/tasks/task_e_6896c0f718b88333bef3eb2a78c69136