### PR TITLE
Refactor templates into dedicated files

### DIFF
--- a/templates/file_list.html
+++ b/templates/file_list.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>File Manager</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .file-list { list-style: none; padding: 0; }
+        .file-item { 
+            display: flex; 
+            align-items: center; 
+            padding: 8px; 
+            border-bottom: 1px solid #eee; 
+        }
+        .file-name { 
+            flex: 1; 
+            margin-right: 10px; 
+        }
+        .directory { font-weight: bold; color: #0066cc; }
+        .python-file { color: #ff6600; }
+        .run-btn { 
+            background: #28a745; 
+            color: white; 
+            border: none; 
+            padding: 5px 10px; 
+            border-radius: 3px; 
+            cursor: pointer; 
+            margin-left: 5px; 
+        }
+        .run-btn:hover { background: #218838; }
+        .view-btn { 
+            background: #007bff; 
+            color: white; 
+            border: none; 
+            padding: 5px 10px; 
+            border-radius: 3px; 
+            cursor: pointer; 
+            margin-left: 5px; 
+        }
+        .view-btn:hover { background: #0056b3; }
+        .action-buttons { display: flex; gap: 5px; }
+        .flash-messages { margin-bottom: 20px; }
+        .flash-success { color: green; background: #d4edda; padding: 10px; border-radius: 3px; margin: 5px 0; }
+        .flash-error { color: red; background: #f8d7da; padding: 10px; border-radius: 3px; margin: 5px 0; }
+        .flash-info { color: blue; background: #d1ecf1; padding: 10px; border-radius: 3px; margin: 5px 0; }
+        .current-dir { color: #666; margin-bottom: 20px; }
+        .breadcrumb { 
+            margin-bottom: 15px; 
+            padding: 10px; 
+            background: #f8f9fa; 
+            border-radius: 3px; 
+        }
+        .breadcrumb a { 
+            color: #007bff; 
+            text-decoration: none; 
+            margin-right: 5px; 
+        }
+        .breadcrumb a:hover { text-decoration: underline; }
+        .folder-link { 
+            text-decoration: none; 
+            color: #0066cc; 
+            cursor: pointer; 
+        }
+        .folder-link:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <h1>File Manager</h1>
+    <div class="current-dir">Current Directory: {{ current_dir }}</div>
+    
+    <!-- Breadcrumb Navigation -->
+    <div class="breadcrumb">
+        <a href="{{ url_for('file_list') }}">🏠 Home</a>
+        {% for crumb in breadcrumbs %}
+            / <a href="{{ url_for('file_list', subpath=crumb.path) }}">{{ crumb.name }}</a>
+        {% endfor %}
+    </div>
+    
+    <div class="flash-messages">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+                {% for category, message in messages %}
+                    <div class="flash-{{ category }}">{{ message }}</div>
+                {% endfor %}
+            {% endif %}
+        {% endwith %}
+    </div>
+    
+    <ul class="file-list">
+        {% for file in files %}
+            <li class="file-item">
+                {% if not file.is_file %}
+                    <a href="{{ url_for('file_list', subpath=(subpath + '/' + file.name) if subpath else file.name) }}" class="folder-link">
+                        <span class="file-name directory">
+                            📁 {{ file.name }}
+                        </span>
+                    </a>
+                {% else %}
+                    <span class="file-name {% if file.is_python %}python-file{% endif %}">
+                        📄 {{ file.name }}
+                        {% if file.size %}({{ "%.1f"|format(file.size/1024) }} KB){% endif %}
+                    </span>
+                    <div class="action-buttons">
+                        {% set file_ext = file.name.split('.')[-1].lower() %}
+                        {% if file.is_python or file_ext in ['txt', 'md', 'json', 'xml', 'html', 'css', 'js', 'ts', 'yml', 'yaml', 'toml', 'ini', 'cfg', 'log'] %}
+                            <a href="{{ url_for('view_file', filepath=(subpath + '/' + file.name) if subpath else file.name) }}">
+                                <button class="view-btn">👁 View</button>
+                            </a>
+                        {% endif %}
+                        {% if file.is_python %}
+                            <a href="{{ url_for('run_script', filepath=(subpath + '/' + file.name) if subpath else file.name) }}">
+                                <button class="run-btn">▶ Run</button>
+                            </a>
+                        {% endif %}
+                    </div>
+                {% endif %}
+            </li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/templates/file_view.html
+++ b/templates/file_view.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ filename }} - File Viewer</title>
+    <style>
+        body { 
+            font-family: Arial, sans-serif; 
+            margin: 20px; 
+            background-color: #f8f9fa; 
+        }
+        .header { 
+            background: white; 
+            padding: 20px; 
+            border-radius: 5px; 
+            margin-bottom: 20px; 
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1); 
+        }
+        .breadcrumb { 
+            margin-bottom: 15px; 
+            padding: 10px; 
+            background: #e9ecef; 
+            border-radius: 3px; 
+        }
+        .breadcrumb a { 
+            color: #007bff; 
+            text-decoration: none; 
+            margin-right: 5px; 
+        }
+        .breadcrumb a:hover { text-decoration: underline; }
+        .back-btn { 
+            background: #6c757d; 
+            color: white; 
+            border: none; 
+            padding: 8px 16px; 
+            border-radius: 3px; 
+            cursor: pointer; 
+            text-decoration: none; 
+            display: inline-block; 
+            margin-right: 10px; 
+        }
+        .back-btn:hover { background: #545b62; }
+        .file-content { 
+            background: white; 
+            padding: 20px; 
+            border-radius: 5px; 
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1); 
+            overflow: auto; 
+        }
+        .code-content { 
+            font-family: 'Courier New', monospace; 
+            font-size: 14px; 
+            line-height: 1.4; 
+            background: #f8f9fa; 
+            padding: 15px; 
+            border-radius: 3px; 
+            border: 1px solid #dee2e6; 
+            white-space: pre-wrap; 
+            word-wrap: break-word; 
+            max-height: 80vh; 
+            overflow-y: auto; 
+        }
+        .file-info { 
+            color: #666; 
+            font-size: 14px; 
+            margin-bottom: 15px; 
+        }
+        .python-syntax { color: #0000ff; }
+        .line-numbers { 
+            display: table; 
+            width: 100%; 
+        }
+        .line { 
+            display: table-row; 
+        }
+        .line-number { 
+            display: table-cell; 
+            text-align: right; 
+            padding-right: 10px; 
+            color: #999; 
+            border-right: 1px solid #ddd; 
+            min-width: 50px; 
+            user-select: none; 
+        }
+        .line-content { 
+            display: table-cell; 
+            padding-left: 10px; 
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <div class="breadcrumb">
+            <a href="{{ url_for('file_list') }}">🏠 Home</a>
+            {% for crumb in breadcrumbs %}
+                / <a href="{{ url_for('file_list', subpath=crumb.path) }}">{{ crumb.name }}</a>
+            {% endfor %}
+            {% if breadcrumbs %}
+                / {{ filename }}
+            {% else %}
+                / {{ filename }}
+            {% endif %}
+        </div>
+        
+        {% if subpath %}
+            <a href="{{ url_for('file_list', subpath=subpath) }}" class="back-btn">← Back to Directory</a>
+        {% else %}
+            <a href="{{ url_for('file_list') }}" class="back-btn">← Back to Directory</a>
+        {% endif %}
+        
+        <h1>📄 {{ filename }}</h1>
+        <div class="file-info">
+            File: {{ filepath }} | Size: {{ content|length }} characters
+        </div>
+    </div>
+    
+    <div class="file-content">
+        <div class="code-content line-numbers">
+            {% set lines = content.split('\n') %}
+            {% for line in lines %}
+                <div class="line">
+                    <div class="line-number">{{ loop.index }}</div>
+                    <div class="line-content">{{ line if line else ' ' }}</div>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move inline HTML_TEMPLATE and FILE_VIEW_TEMPLATE into templates/file_list.html and templates/file_view.html
- use Flask's render_template to load external templates instead of render_template_string

## Testing
- `python -m py_compile flasky.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896c10888148333bf262f85de60a60f