### PR TITLE
Improve clipboard logger

### DIFF
--- a/clip.py
+++ b/clip.py
@@ -1,16 +1,74 @@
+"""Simple clipboard logger.
+
+This module provides a function :func:`clipboard_logger` that prints new
+clipboard values as they are copied.  Optionally, a list can be supplied to
+collect the clipboard history.  The script can be run directly and supports a
+``--duration`` flag to stop logging after a specified number of seconds.
+Clipboard access failures from :mod:`pyperclip` are caught to prevent crashes.
+"""
+
+from __future__ import annotations
+
+import argparse
 import time
+
 import pyperclip
 
-history = []
 
-def clipboard_logger():
+def clipboard_logger(duration: float | None = None, history: list[str] | None = None) -> list[str] | None:
+    """Log clipboard changes until duration expires or interrupted.
+
+    Parameters
+    ----------
+    duration:
+        Number of seconds to run.  If ``None`` (the default) the logger runs
+        until interrupted.
+    history:
+        Optional list used to store the clipboard history.  When provided, each
+        new clipboard entry is appended to this list and it is returned when the
+        logger exits.
+
+    Returns
+    -------
+    list[str] | None
+        The ``history`` list if supplied; otherwise ``None``.
+    """
+
     recent_value = ""
+    start_time = time.time()
+
     while True:
-        tmp_value = pyperclip.paste()
+        try:
+            tmp_value = pyperclip.paste()
+        except pyperclip.PyperclipException as exc:  # type: ignore[attr-defined]
+            print(f"Clipboard access failed: {exc}")
+            break
+
         if tmp_value != recent_value:
             recent_value = tmp_value
-            history.append(recent_value)
+            if history is not None:
+                history.append(recent_value)
             print(f"Copied: {recent_value}")
+
+        if duration is not None and time.time() - start_time >= duration:
+            break
+
         time.sleep(1)
 
-clipboard_logger()
+    return history
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Log clipboard changes.")
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="Run time in seconds. Defaults to run until interrupted.",
+    )
+    args = parser.parse_args()
+
+    try:
+        clipboard_logger(duration=args.duration)
+    except KeyboardInterrupt:
+        print("\nLogging stopped by user.")


### PR DESCRIPTION
## Summary
- refactor clipboard logger to be callable and optionally track history
- add --duration flag and main guard for controlled execution
- handle pyperclip access failures gracefully

## Testing
- `python -m py_compile clip.py`
- `python clip.py --duration 0` *(fails: ModuleNotFoundError: No module named 'pyperclip')*
- `pip install pyperclip` *(fails: Could not find a version that satisfies the requirement pyperclip)*

------
https://chatgpt.com/codex/tasks/task_e_6896c12183a083339bfcf5cf5948b61c