### PR TITLE
Improve battery monitor for cross-platform use and robust battery readings

### DIFF
--- a/bat.py
+++ b/bat.py
@@ -1,20 +1,36 @@
-import psutil
+import os
 import time
-import sys
-import msvcrt
+
+import psutil
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import keyboard
+
 
 def battery_alert():
     print("Press ESC to stop monitoring...")
     while True:
-        if msvcrt.kbhit():
-            key = msvcrt.getch()
-            if key == b'\x1b':  # ESC key
+        if os.name == "nt":
+            if msvcrt.kbhit():
+                key = msvcrt.getch()
+                if key == b"\x1b":
+                    print("\nStopping battery monitor...")
+                    break
+        else:
+            if keyboard.is_pressed("esc"):
                 print("\nStopping battery monitor...")
                 break
         battery = psutil.sensors_battery()
+        if battery is None:
+            print("No battery information available.")
+            break
         print(f"🔋 Battery: {battery.percent}%")
         if battery.percent < 15 and not battery.power_plugged:
             print("⚠️  Battery low! Plug in the charger.")
         time.sleep(1)
 
-battery_alert()
+
+if __name__ == "__main__":
+    battery_alert()


### PR DESCRIPTION
## Summary
- Guard `battery_alert()` behind `if __name__ == "__main__"` and remove unused imports
- Import `msvcrt` only on Windows and fall back to the cross-platform `keyboard` library elsewhere
- Handle missing battery info from `psutil.sensors_battery()`

## Testing
- `python -m ruff check bat.py`
- `python -m black bat.py --config /dev/null`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896c12c57a88333ae946b21f34605ed