### PR TITLE
Remove references to nonexistent main launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,6 @@ System battery monitoring and notification tool.
 
 WiFi network management and monitoring utility.
 
----
-
-### Main - Entry Point
-**File**: `main.py`
-
-Main entry point and tool launcher.
-
 ## Development
 
 ### Project Structure
@@ -97,15 +90,14 @@ Main entry point and tool launcher.
 tools/
 ├── README.md           # This file
 ├── pyproject.toml      # Project configuration
-├── uv.lock            # Lock file
+├── uv.lock             # Lock file
 ├── .gitignore          # Git ignore rules
 ├── flasky.py           # Web file manager
 ├── clip.py             # Clipboard utility
 ├── webfolder.py        # Web directory server
 ├── cron.py             # Task scheduler
 ├── bat.py              # Battery monitor
-├── wifi.py             # WiFi manager
-└── main.py             # Main entry point
+└── wifi.py             # WiFi manager
 ```
 
 ### Running Individual Tools


### PR DESCRIPTION
## Summary
- clarify that tools run individually and remove outdated main launcher mention
- update project structure to list only existing tool scripts

## Testing
- `ruff check .` *(fails: Import block un-sorted, unused imports, etc.)*
- `black .` *(fails: Config key exclude must be a string)*
- `isort .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896c14297a0833396dac6a4e5f86ce5